### PR TITLE
Add Dismount and Explosion Damage flags

### DIFF
--- a/src/main/java/org/cubeville/cvflags/CVFlags.java
+++ b/src/main/java/org/cubeville/cvflags/CVFlags.java
@@ -75,6 +75,8 @@ public final class CVFlags extends JavaPlugin implements Listener {
                 getServer().getPluginManager().registerEvents(new ElytraPVPFlag(), this);
                 getServer().getPluginManager().registerEvents(new EnderChestFlag(), this);
                 getServer().getPluginManager().registerEvents(new LocalDeathMessageFlag(), this);
+                getServer().getPluginManager().registerEvents(new DismountFlag(), this);
+                getServer().getPluginManager().registerEvents(new ExplosionDamageFlag(), this);
         }
 
         public static CVFlags getInstance() {

--- a/src/main/java/org/cubeville/cvflags/CVFlags.java
+++ b/src/main/java/org/cubeville/cvflags/CVFlags.java
@@ -75,7 +75,6 @@ public final class CVFlags extends JavaPlugin implements Listener {
                 getServer().getPluginManager().registerEvents(new ElytraPVPFlag(), this);
                 getServer().getPluginManager().registerEvents(new EnderChestFlag(), this);
                 getServer().getPluginManager().registerEvents(new LocalDeathMessageFlag(), this);
-                getServer().getPluginManager().registerEvents(new DismountFlag(), this);
                 getServer().getPluginManager().registerEvents(new ExplosionDamageFlag(), this);
         }
 

--- a/src/main/java/org/cubeville/cvflags/Flags.java
+++ b/src/main/java/org/cubeville/cvflags/Flags.java
@@ -9,6 +9,5 @@ public final class Flags {
         public final static StateFlag LOCAL_DEATH_MESSAGE = new StateFlag("local-death-message", false);
         public final static StateFlag ENDER_CHEST = new StateFlag("ender-chest", true);
         public final static StringFlag PLAYER_CHECK = new StringFlag("pcheck");
-        public final static StateFlag DISMOUNT = new StateFlag("dismount", true);
         public final static StateFlag EXPLOSION_DAMAGE = new StateFlag("explosion-damage", true);
 }

--- a/src/main/java/org/cubeville/cvflags/Flags.java
+++ b/src/main/java/org/cubeville/cvflags/Flags.java
@@ -9,4 +9,6 @@ public final class Flags {
         public final static StateFlag LOCAL_DEATH_MESSAGE = new StateFlag("local-death-message", false);
         public final static StateFlag ENDER_CHEST = new StateFlag("ender-chest", true);
         public final static StringFlag PLAYER_CHECK = new StringFlag("pcheck");
+        public final static StateFlag DISMOUNT = new StateFlag("dismount", true);
+        public final static StateFlag EXPLOSION_DAMAGE = new StateFlag("explosion-damage", true);
 }

--- a/src/main/java/org/cubeville/cvflags/flags/DismountFlag.java
+++ b/src/main/java/org/cubeville/cvflags/flags/DismountFlag.java
@@ -1,0 +1,29 @@
+package org.cubeville.cvflags.flags;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.scheduler.BukkitScheduler;
+import org.cubeville.cvflags.CVFlags;
+import org.cubeville.cvflags.Flags;
+import org.spigotmc.event.entity.EntityDismountEvent;
+
+public class DismountFlag implements Listener {
+
+    @EventHandler
+    public void onPlayerDismount(EntityDismountEvent event) {
+        // continue if the entity dismounting is a player
+        if (!(event.getEntity() instanceof Player)) return;
+        Player player = (Player) event.getEntity();
+        // continue if the dismount flag is set to false
+        if (CVFlags.isFlagTrue(Flags.DISMOUNT, player, player.getLocation())) return;
+        // cancel the event!
+        event.setCancelled(true);
+    }
+
+}

--- a/src/main/java/org/cubeville/cvflags/flags/DismountFlag.java
+++ b/src/main/java/org/cubeville/cvflags/flags/DismountFlag.java
@@ -5,25 +5,42 @@ import org.bukkit.Material;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.scheduler.BukkitScheduler;
 import org.cubeville.cvflags.CVFlags;
 import org.cubeville.cvflags.Flags;
 import org.spigotmc.event.entity.EntityDismountEvent;
+import org.spigotmc.event.entity.EntityMountEvent;
+
+import java.util.UUID;
 
 public class DismountFlag implements Listener {
 
+    // BECAUSE PROBLEMS, THIS CODE IS NOT CURRENTLY IMPLEMENTED.
     @EventHandler
     public void onPlayerDismount(EntityDismountEvent event) {
         // continue if the entity dismounting is a player
         if (!(event.getEntity() instanceof Player)) return;
         Player player = (Player) event.getEntity();
         // continue if the dismount flag is set to false
-        if (CVFlags.isFlagTrue(Flags.DISMOUNT, player, player.getLocation())) return;
+        // if (CVFlags.isFlagTrue(Flags.DISMOUNT, player, player.getLocation())) return;
         // cancel the event!
         event.setCancelled(true);
+        // add the player back in 1 tick
+        Entity dismounted = event.getDismounted();
+        UUID pUUID = player.getUniqueId();
+        BukkitScheduler scheduler = Bukkit.getScheduler();
+        scheduler.runTaskLater(CVFlags.getInstance(), () -> {
+            Player p = Bukkit.getPlayer(pUUID);
+            if (p != null && p.isOnline()) {
+                dismounted.addPassenger(p);
+            }
+        }, 1L);
     }
+
 
 }

--- a/src/main/java/org/cubeville/cvflags/flags/ExplosionDamageFlag.java
+++ b/src/main/java/org/cubeville/cvflags/flags/ExplosionDamageFlag.java
@@ -1,0 +1,23 @@
+package org.cubeville.cvflags.flags;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.cubeville.cvflags.CVFlags;
+import org.cubeville.cvflags.Flags;
+
+public class ExplosionDamageFlag implements Listener {
+    @EventHandler
+        public void onPlayerDamage(EntityDamageEvent event) {
+        // continue if the entity being damaged is a player
+        if (!(event.getEntity() instanceof Player)) return;
+        Player player = (Player) event.getEntity();
+        // continue if the cause is an explosion of some sort
+        if (event.getCause() != EntityDamageEvent.DamageCause.BLOCK_EXPLOSION && event.getCause() != EntityDamageEvent.DamageCause.ENTITY_EXPLOSION) return;
+        // continue if the explosion damage flag is set to false
+        if (CVFlags.isFlagTrue(Flags.EXPLOSION_DAMAGE, player, player.getLocation())) return;
+        // cancel the event!
+        event.setCancelled(true);
+    }
+}


### PR DESCRIPTION
Dismount flag allows regions to disable players from dismounting.
Explosion Damage flag allows regions to prevent players who are in it from taking damage from explosions.

Known bug, if you teleport in-world you seem like you've teleported away but you're still in reality in the vehicle. I tried making it to where you get put back in the vehicle after the cancel, but there were some massive problems with that, mostly with error spam about not being able to teleport players that are not online, causing massive lag. I suppose _maybe_ a scheduler would work better, but I forgot to test that. And I did still have problems even when I checked if a player was online before adding them back as a passenger, if I recall correctly. So I don't really know what the best answer is.